### PR TITLE
Add new tests with plain text.

### DIFF
--- a/test/mcrypto/hasher/keccak_test.exs
+++ b/test/mcrypto/hasher/keccak_test.exs
@@ -2,16 +2,18 @@ defmodule McryptoTest.Keccak do
   use ExUnit.Case
   alias Mcrypto.Hasher.Keccak
 
+  @message Base.decode16!("68656C6C6F")
+
   test "keccakf1600 hash should work as expected" do
     assert Mcrypto.hash(%Keccak{}, "") ===
              <<197, 210, 70, 1, 134, 247, 35, 60, 146, 126, 125, 178, 220, 199, 3, 192, 229, 0,
                182, 83, 202, 130, 39, 59, 123, 250, 216, 4, 93, 133, 164, 112>>
 
-    assert Mcrypto.hash(%Keccak{}, "hello") ===
+    assert Mcrypto.hash(%Keccak{}, @message) ===
              <<28, 138, 255, 149, 6, 133, 194, 237, 75, 195, 23, 79, 52, 114, 40, 123, 86, 217,
                81, 123, 156, 148, 129, 39, 49, 154, 9, 167, 163, 109, 234, 200>>
 
-    assert Mcrypto.hash(%Keccak{size: 384}, "hello") ===
+    assert Mcrypto.hash(%Keccak{size: 384}, @message) ===
              <<220, 239, 111, 183, 144, 143, 213, 43, 162, 106, 171, 167, 81, 33, 82, 106, 187,
                241, 33, 127, 28, 10, 49, 2, 70, 82, 209, 52, 211, 227, 47, 180, 205, 142, 156,
                112, 59, 143, 67, 231, 39, 123, 89, 165, 205, 64, 33, 117>>

--- a/test/mcrypto/hasher/sha2_test.exs
+++ b/test/mcrypto/hasher/sha2_test.exs
@@ -2,20 +2,22 @@ defmodule McryptoTest.Sha2 do
   use ExUnit.Case
   alias Mcrypto.Hasher.Sha2
 
+  @message Base.decode16!("68656C6C6F")
+
   test "sha2 hash shall work as expected" do
     assert Mcrypto.hash(%Sha2{}, "") ===
              <<93, 246, 224, 226, 118, 19, 89, 211, 10, 130, 117, 5, 142, 41, 159, 204, 3, 129,
                83, 69, 69, 245, 92, 244, 62, 65, 152, 63, 93, 76, 148, 86>>
 
-    assert Mcrypto.hash(%Sha2{round: 1}, "hello") ===
+    assert Mcrypto.hash(%Sha2{round: 1}, @message) ===
              <<44, 242, 77, 186, 95, 176, 163, 14, 38, 232, 59, 42, 197, 185, 226, 158, 27, 22,
                30, 92, 31, 167, 66, 94, 115, 4, 51, 98, 147, 139, 152, 36>>
 
-    assert Mcrypto.hash(%Sha2{}, "hello") ===
+    assert Mcrypto.hash(%Sha2{}, @message) ===
              <<149, 149, 201, 223, 144, 7, 81, 72, 235, 6, 134, 3, 101, 223, 51, 88, 75, 117, 191,
                247, 130, 165, 16, 198, 205, 72, 131, 164, 25, 131, 61, 80>>
 
-    assert Mcrypto.hash(%Sha2{size: 384}, "hello") ===
+    assert Mcrypto.hash(%Sha2{size: 384}, @message) ===
              <<212, 125, 137, 255, 213, 7, 30, 130, 96, 205, 111, 202, 26, 70, 104, 96, 88, 113,
                175, 95, 190, 219, 237, 115, 117, 161, 17, 124, 140, 20, 200, 45, 60, 234, 194, 52,
                77, 209, 224, 48, 53, 174, 28, 94, 117, 92, 245, 242>>

--- a/test/mcrypto/hasher/sha3_test.exs
+++ b/test/mcrypto/hasher/sha3_test.exs
@@ -2,16 +2,18 @@ defmodule McryptoTest.Sha3 do
   use ExUnit.Case
   alias Mcrypto.Hasher.Sha3
 
+  @message Base.decode16!("68656C6C6F")
+
   test "sha3 hash shall work as expected" do
     assert Mcrypto.hash(%Sha3{}, "") ===
              <<167, 255, 198, 248, 191, 30, 215, 102, 81, 193, 71, 86, 160, 97, 214, 98, 245, 128,
                255, 77, 228, 59, 73, 250, 130, 216, 10, 75, 128, 248, 67, 74>>
 
-    assert Mcrypto.hash(%Sha3{}, "hello") ===
+    assert Mcrypto.hash(%Sha3{}, @message) ===
              <<51, 56, 190, 105, 79, 80, 197, 243, 56, 129, 73, 134, 205, 240, 104, 100, 83, 168,
                136, 184, 79, 66, 77, 121, 42, 244, 185, 32, 35, 152, 243, 146>>
 
-    assert Mcrypto.hash(%Sha3{size: 384}, "hello") ===
+    assert Mcrypto.hash(%Sha3{size: 384}, @message) ===
              <<114, 10, 234, 17, 1, 158, 240, 100, 64, 251, 240, 93, 135, 170, 36, 104, 10, 33,
                83, 223, 57, 7, 178, 54, 49, 231, 23, 124, 230, 32, 250, 19, 48, 255, 7, 192, 253,
                222, 229, 70, 153, 164, 195, 238, 14, 233, 216, 135>>

--- a/test/mcrypto/signer/ed25519_test.exs
+++ b/test/mcrypto/signer/ed25519_test.exs
@@ -2,25 +2,51 @@ defmodule McryptoTest.Ed25519 do
   use ExUnit.Case
   alias Mcrypto.Signer.Ed25519
 
-  test "create keypair for ed25519" do
-    signer = %Ed25519{}
+  @signer %Ed25519{}
 
-    {pk, sk} = Mcrypto.keypair(signer)
+  test "create keypair for ed25519" do
+    {pk, sk} = Mcrypto.keypair(@signer)
     assert pk === :libdecaf_curve25519.eddsa_sk_to_pk(sk)
   end
 
   test "sk to pk should work" do
-    signer = %Ed25519{}
-
-    {pk, sk} = Mcrypto.keypair(signer)
-    assert pk === Mcrypto.sk_to_pk(signer, sk)
+    {pk, sk} = Mcrypto.keypair(@signer)
+    assert pk === Mcrypto.sk_to_pk(@signer, sk)
   end
 
   test "signature shall be verified" do
-    signer = %Ed25519{}
-    {pk, sk} = Mcrypto.keypair(signer)
+    {pk, sk} = Mcrypto.keypair(@signer)
 
-    signature = Mcrypto.sign!(signer, "hello world", sk)
-    assert Mcrypto.verify(signer, "hello world", signature, pk) === true
+    signature = Mcrypto.sign!(@signer, "hello world", sk)
+    assert Mcrypto.verify(@signer, "hello world", signature, pk) === true
+  end
+
+  test "secret key to public key" do
+    sk =
+      "D67C071B6F51D2B61180B9B1AA9BE0DD0704619F0E30453AB4A592B036EDE644E4852B7091317E3622068E62A5127D1FB0D4AE2FC50213295E10652D2F0ABFC7"
+      |> Base.decode16!()
+
+    pk = "E4852B7091317E3622068E62A5127D1FB0D4AE2FC50213295E10652D2F0ABFC7" |> Base.decode16!()
+
+    assert pk === Mcrypto.sk_to_pk(@signer, sk)
+  end
+
+  test "sign and verify" do
+    sk =
+      "D67C071B6F51D2B61180B9B1AA9BE0DD0704619F0E30453AB4A592B036EDE644E4852B7091317E3622068E62A5127D1FB0D4AE2FC50213295E10652D2F0ABFC7"
+      |> Base.decode16!()
+
+    pk = "E4852B7091317E3622068E62A5127D1FB0D4AE2FC50213295E10652D2F0ABFC7" |> Base.decode16!()
+
+    message =
+      "15D0014A9CF581EC068B67500683A2784A15E1F68057E5E37AAF3A0F58F3C43F083D6A5630130399D4E5003EA191FDE30849"
+      |> Base.decode16!()
+
+    signature =
+      "321EE8262407BF091F16ED190A3074339EBDF956B3924A9CF29B86A366C9570C72C6A8D8363705182D5A99FAF152C617FD89D291C9D944F2A95DF57019303200"
+      |> Base.decode16!()
+
+    assert signature === Mcrypto.sign!(@signer, message, sk)
+    assert Mcrypto.verify(@signer, message, signature, pk)
   end
 end

--- a/test/mcrypto/signer/secp256k1_test.exs
+++ b/test/mcrypto/signer/secp256k1_test.exs
@@ -2,20 +2,51 @@ defmodule McryptoTest.Secp256k1 do
   use ExUnit.Case
   alias Mcrypto.Signer.Secp256k1
 
-  test "create keypair for secp256k1" do
-    signer = %Secp256k1{}
+  @signer %Secp256k1{}
 
-    {pk, sk} = Mcrypto.keypair(signer)
+  test "create keypair for secp256k1" do
+    {pk, sk} = Mcrypto.keypair(@signer)
     {:ok, pk1} = :libsecp256k1.ec_pubkey_create(sk, :uncompressed)
 
     assert pk1 === pk
   end
 
   test "signature shall be verified" do
-    signer = %Secp256k1{}
-    {pk, sk} = Mcrypto.keypair(signer)
+    {pk, sk} = Mcrypto.keypair(@signer)
 
-    signature = Mcrypto.sign!(signer, "hello world", sk)
-    assert Mcrypto.verify(signer, "hello world", signature, pk) === true
+    signature = Mcrypto.sign!(@signer, "hello world", sk)
+    assert Mcrypto.verify(@signer, "hello world", signature, pk) === true
+  end
+
+  # Same secret key as https://en.bitcoin.it/wiki/Technical_background_of_version_1_Bitcoin_addresses
+  test "sk to pk" do
+    sk = "18E14A7B6A307F426A94F8114701E7C8E774E7F9A47E2C2035DB29A206321725" |> Base.decode16!()
+
+    # This is the uncompressed format of the public key
+    pk =
+      "0450863AD64A87AE8A2FE83C1AF1A8403CB53F53E486D8511DAD8A04887E5B23522CD470243453A299FA9E77237716103ABC11A1DF38855ED6F2EE187E9C582BA6"
+      |> Base.decode16!()
+
+    assert pk === Mcrypto.sk_to_pk(@signer, sk)
+  end
+
+  test "sign and verify" do
+    sk = "18E14A7B6A307F426A94F8114701E7C8E774E7F9A47E2C2035DB29A206321725" |> Base.decode16!()
+
+    # This is the uncompressed format of the public key
+    pk =
+      "0450863AD64A87AE8A2FE83C1AF1A8403CB53F53E486D8511DAD8A04887E5B23522CD470243453A299FA9E77237716103ABC11A1DF38855ED6F2EE187E9C582BA6"
+      |> Base.decode16!()
+
+    message =
+      "15D0014A9CF581EC068B67500683A2784A15E1F68057E5E37AAF3A0F58F3C43F083D6A5630130399D4E5003EA191FDE30849"
+      |> Base.decode16!()
+
+    signature =
+      "3045022100942F2DB25D6A0F6B01B195EDBAD8BB8F58F4EE85C7D5E1934649781D815F7ECE0220158DD32CB48D2A3A97267F4416A53692C51C72CD350F945D7BEA60376FD658D5"
+      |> Base.decode16!()
+
+    assert signature === Mcrypto.sign!(@signer, message, sk)
+    assert Mcrypto.verify(@signer, message, signature, pk)
   end
 end


### PR DESCRIPTION
These tests serve as reference for other folks for them to find DSA and hash libraries on mobile and web platform.

@NateRobinson @wangshijun @jonathanlu813 @PaperHS 
You can compare the keys and signatures generated by the libraries you found with the values in these tests.

Notes:
1. For ed25519, we typically use a 64-bytes long secret key and the public key is actually the latter 32 bytes of the secret key.
2. For secp256k1, we are using the uncompressed version of public key instead of the compressed version like BTC. You can find more details here:
https://en.bitcoin.it/wiki/Technical_background_of_version_1_Bitcoin_addresses
https://davidederosa.com/basic-blockchain-programming/elliptic-curve-keys/